### PR TITLE
Move serilog config to appesttings.json file

### DIFF
--- a/SamplePlugin/Program.cs
+++ b/SamplePlugin/Program.cs
@@ -1,11 +1,14 @@
 ﻿using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 using Serilog;
+using Serilog.Settings.Configuration;
 using StreamDeckLib;
 using System;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace SamplePlugin
 {
@@ -31,14 +34,15 @@ namespace SamplePlugin
 
 			var source = new CancellationTokenSource();
 
-			var logLocation = Path.Combine(Path.GetTempPath(), $"{GetType().Assembly.GetName().Name}-.log");
+            Directory.SetCurrentDirectory(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
 
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .Build();
 
-			Log.Logger = new LoggerConfiguration()
-				.MinimumLevel.Verbose()
-				.Enrich.FromLogContext()
-				.WriteTo.File(logLocation, rollingInterval: RollingInterval.Day)
-				.CreateLogger();
+            Log.Logger = new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration)
+                .CreateLogger();
 
 			var loggerFactory = new LoggerFactory()
 				.AddSerilog(Log.Logger);

--- a/SamplePlugin/SamplePlugin.csproj
+++ b/SamplePlugin/SamplePlugin.csproj
@@ -11,6 +11,7 @@
     <None Remove="actionDefaultImage.png" />
     <None Remove="actionIcon%402x.png" />
     <None Remove="actionIcon.png" />
+    <None Remove="appsettings.json" />
     <None Remove="manifest.json" />
     <None Remove="pluginIcon%402x.png" />
     <None Remove="pluginIcon.png" />
@@ -35,15 +36,23 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\StreamDeckLib\StreamDeckLib.csproj" />
   </ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 		<PackageReference Include="Serilog" Version="2.7.1" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
 		<PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
 	</ItemGroup>

--- a/SamplePlugin/appsettings.json
+++ b/SamplePlugin/appsettings.json
@@ -1,0 +1,16 @@
+﻿{
+  "Serilog": {
+    "MinimumLevel": "Debug",
+    "WriteTo": [
+      {
+        "Name": "File",
+        "Args": {
+          "path": "log/sampleplugin.log",
+          "rollingInterval": "Day",
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} {Message} {NewLine}{Exception}"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext" ]
+  }
+}


### PR DESCRIPTION
Allow Serilog configuration via appsettings.json.
The approach is much more flexible and even allows to add information like
https://github.com/serilog/serilog-enrichers-environment
without code changes by only adding the requiered DLLs and the config.
Also adding and configuring sinks like elasticsearch or seq is now add dll and change configuration only.

Only disadvantage I know at the moment is that you have to give the "exact" file path in the config setting. 
The implementation as checked in will try to write into a log folder within the directory of the executable.

By the way in the twitch stream I am known as Tagaron1.